### PR TITLE
#152919412 centers template page

### DIFF
--- a/template/centers.html
+++ b/template/centers.html
@@ -121,9 +121,13 @@
                         <h6 class="card-subtitle mb-2 text-muted">Center address</h6>
                         <p class="card-text">Description....</p>
                         <div class="d-flex flex-wrap justify-content-end grp">
-                            <button type="button" class="btn btn-primary grp-btn">Add Event</button>
-                            <button type="button" class="btn btn-primary grp-btn disabled">Edit</button>
-                            <button type="button" class="btn btn-danger grp-btn disabled">Delete</button>
+                            <a href="./add-event.html">
+                                <button type="button" class="btn btn-primary grp-btn">Add Event</button>
+                            </a>
+                            <a href="./add-center.html">
+                                <button type="button" class="btn btn-primary grp-btn disabled">Edit</button>
+                            </a>
+                            <button type="button" class="btn btn-danger grp-btn disabled" href="#">Delete</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
#### What does this do
 - Adds 'href' to action buttons
 - 'Edit' button navigates to 'create center page
 - 'Add Event' button navigates to 'add event' page

#### Task to be completed
 - Styling of page 
 - Add footer

#### How to test features
 - Navigate to https://liadi.github.io/events-manager/template/centers.html
 - Test responsiveness using developer tools
 OR
 - Clone repo(for commit history)
 - Ensure branch is 'ch-all-centers-template-page-152919412' 
 - Open browser
 - Navigate to [repo base path]/template/centers.html

##### Background context
 - For Implementation, when edit is clicked user should be navigated to the create cente page, but fields should be pre-populated
#### Related PiivotalTracker stories
 - #152919412
#### Screenshots
 -  None
#### Questions
 - None